### PR TITLE
Fixed add_translation overwriting

### DIFF
--- a/reticulator/reticulator.py
+++ b/reticulator/reticulator.py
@@ -910,9 +910,14 @@ class LanguageFile(FileResource):
         Adds a new translation key. Overwrites by default.
         """
 
-        # We must complain about duplicates, unless
-        if self.contains_translation(translation.key) and not overwrite:
-            return False
+        # We must complain about duplicates.
+        # If no overwrite, don't add
+        # If overwrite, delete previous translation
+        if self.contains_translation(translation.key):
+            if not overwrite:
+                return False
+            else:
+                self.delete_translation(translation.key)
 
         self.dirty = True
         self.__translations.append(translation)

--- a/test/test.py
+++ b/test/test.py
@@ -618,6 +618,20 @@ class TestLanguageFiles(unittest.TestCase):
         translation = language_file.get_translation('new_key2')
         self.assertEqual(translation.comment, 'Test')
 
+    def test_overwrite_translation(self):
+        language_file = self.rp.get_language_file('texts/es_ES.lang')
+        language_file.add_translation(Translation('accessibility.text.period', 'Test 1'),overwrite=True)
+        language_file.add_translation(Translation('accessibility.text.comma', 'Test 2'),overwrite=False)
+
+        saved_bp, saved_rp = save_and_return_packs(rp=self.rp)
+
+        language_file = saved_rp.get_language_file('texts/es_ES.lang')
+        self.assertEqual(len(language_file.translations), 3)
+        translation_1 = language_file.get_translation('accessibility.text.period')
+        translation_2 = language_file.get_translation('accessibility.text.comma')
+        self.assertEqual(translation_1.value,'Test 1')
+        self.assertEqual(translation_2.value,'Coma')
+
 class TestJsonPathAccess(unittest.TestCase):
     """
     Test various jsonpath access methods.


### PR DESCRIPTION
Before add_translation just appended the key causing duplicate key errors. Changed it to delete the key if it already exists and overwrite is enabled